### PR TITLE
Add nytaxi and spark pi k8s scripts to image

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -66,5 +66,12 @@ RUN chmod a+x /opt/entrypoint.sh && \
 ADD ../nytaxi/target/spark-azure-nytaxi-1.0-SNAPSHOT-jar-with-dependencies.jar /root/spark-azure-nytaxi-1.0-SNAPSHOT.jar
 RUN cp /root/spark-azure-nytaxi-1.0-SNAPSHOT.jar /opt/bigdl-2.1.0-SNAPSHOT/jars/
 ADD ./run_azure_nytaxi.sh /root/run_azure_nytaxi.sh
+ADD ./run_spark_pi.sh /root/run_spark_pi.sh
+ADD ./run_nytaxi_k8s.sh /root/run_nytaxi_k8s.sh
+ADD ./driver.yaml /root/driver.yaml
+ADD ./executor.yaml /root/executor.yaml
+
+# install azure cli
+RUN curl -sL https://aka.ms/InstallAzureCLIDeb | bash
 
 ENTRYPOINT [ "/opt/entrypoint.sh" ]

--- a/run_nytaxi_k8s.sh
+++ b/run_nytaxi_k8s.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-
+IMAGE=intelanalytics/bigdl-ppml-azure-occlum:2.1.0
 ${SPARK_HOME}/bin/spark-submit \
     --master  k8s://https://${kubernetes_master_url}:${k8s_apiserver_port} \
     --deploy-mode cluster \
@@ -9,7 +9,7 @@ ${SPARK_HOME}/bin/spark-submit \
     --executor-cores 4 \
     --conf spark.executor.instances=1 \
     --conf spark.rpc.netty.dispatcher.numThreads=128 \
-    --conf spark.kubernetes.container.image=intelanalytics/bigdl-ppml-azure-occlum:2.1.0 \
+    --conf spark.kubernetes.container.image=${IMAGE} \
     --conf spark.kubernetes.authenticate.driver.serviceAccountName=spark \
     --conf spark.kubernetes.executor.deleteOnTermination=false \
     --conf spark.kubernetes.driver.podTemplateFile=./driver.yaml \

--- a/run_spark_pi.sh
+++ b/run_spark_pi.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-
+IMAGE=intelanalytics/bigdl-ppml-azure-occlum:2.1.0
 ${SPARK_HOME}/bin/spark-submit \
     --master k8s://https://${kubernetes_master_url}:${k8s_apiserver_port} \
     --deploy-mode cluster \
@@ -7,7 +7,7 @@ ${SPARK_HOME}/bin/spark-submit \
     --class org.apache.spark.examples.SparkPi \
     --conf spark.executor.instances=1 \
     --conf spark.rpc.netty.dispatcher.numThreads=32 \
-    --conf spark.kubernetes.container.image=intelanalytics/bigdl-ppml-azure-occlum:2.1.0 \
+    --conf spark.kubernetes.container.image=${IMAGE} \
     --conf spark.kubernetes.authenticate.driver.serviceAccountName=spark \
     --conf spark.kubernetes.executor.deleteOnTermination=false \
     --conf spark.kubernetes.driver.podTemplateFile=./driver.yaml \


### PR DESCRIPTION
Add nytaxi and spark pi k8s scripts to image, so that users on Azure can run nytaxi and spark pi jobs without cloning this repo. After they pull the image, they can do everything in the image.